### PR TITLE
Remove extra small size

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ const FormGroup = styled.div`
 Name | Type | Default | Description
 :--- | :--- | :------ | :----------
 tag | element | 'div' |
-fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm'<br/>'xs' | 'md' |
+fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm' | 'md' |
 
 #### Input
 
 Name | Type | Default | Description
 :--- | :--- | :------ | :----------
 tag | element | 'input' |
-fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm'<br/>'xs' | 'md' |
+fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm' | 'md' |
 
 #### Select
 
 Name | Type | Default | Description
 :--- | :--- | :------ | :----------
 tag | element | 'select' |
-fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm'<br/>'xs' | 'md' |
+fcSize | One of:<br/>'lg'<br/>'md'<br/>'sm' | 'md' |
 
 #### Textarea
 

--- a/src/form-control.styl
+++ b/src/form-control.styl
@@ -84,14 +84,3 @@
         border-radius: $input-border-radius-sm;
     }
 }
-
-.form-control-xs {
-    height: $input-height-xs;
-    padding: $input-padding-y-xs $input-padding-x-xs;
-    font-size: $input-font-size-xs;
-    line-height: $input-line-height-xs;
-
-    if ($enable-rounded) {
-        border-radius: $input-border-radius-xs;
-    }
-}

--- a/src/variables.styl
+++ b/src/variables.styl
@@ -12,19 +12,16 @@ $disabled = #ddd;
 $font-size-lg = 16px;
 $font-size-md = 13px;
 $font-size-sm = 12px;
-$font-size-xs = 12px;
 $font-weight-base = 400;
 $line-height-lg = 24px;
 $line-height-md = 20px;
 $line-height-sm = 18px;
-$line-height-xs = 18px;
 
 $border-width = 1px;
 $border-color = #ccc;
 $border-radius-lg = 3px;
 $border-radius-md = 3px;
 $border-radius-sm = 3px;
-$border-radius-xs = 3px;
 
 $input-btn-padding-y-lg = 9px;
 $input-btn-padding-x-lg = 12px;
@@ -40,11 +37,6 @@ $input-btn-padding-y-sm = 4px;
 $input-btn-padding-x-sm = 12px;
 $input-btn-font-size-sm = $font-size-sm;
 $input-btn-line-height-sm = $line-height-sm;
-
-$input-btn-padding-y-xs = 1px;
-$input-btn-padding-x-xs = 12px;
-$input-btn-font-size-xs = $font-size-xs;
-$input-btn-line-height-xs = $line-height-xs;
 
 // Forms
 
@@ -65,11 +57,6 @@ $input-padding-x-sm = $input-btn-padding-x-sm;
 $input-font-size-sm = $input-btn-font-size-sm;
 $input-line-height-sm = $input-btn-line-height-sm;
 
-$input-padding-y-xs = $input-btn-padding-y-xs;
-$input-padding-x-xs = $input-btn-padding-x-xs;
-$input-font-size-xs = $input-btn-font-size-xs;
-$input-line-height-xs = $input-btn-line-height-xs;
-
 $input-background-color = $white;
 $input-disabled-background-color = $disabled;
 
@@ -80,7 +67,6 @@ $input-border-width = $border-width;
 $input-border-radius-lg = $border-radius-lg;
 $input-border-radius-md = $border-radius-md;
 $input-border-radius-sm = $border-radius-sm;
-$input-border-radius-xs = $border-radius-xs;
 
 $input-focus-background-color = $input-background-color;
 $input-focus-border-color = $primary;
@@ -99,8 +85,5 @@ $input-height-md = "calc(%s + %s)" % ($input-height-inner-md $input-height-borde
 
 $input-height-inner-sm = ($input-line-height-sm) + ($input-padding-y-sm * 2);
 $input-height-sm = "calc(%s + %s)" % ($input-height-inner-sm $input-height-border);
-
-$input-height-inner-xs = ($input-line-height-xs) + ($input-padding-y-xs * 2);
-$input-height-xs = "calc(%s + %s)" % ($input-height-inner-xs $input-height-border);
 
 $input-transition = border-color .15s ease-in-out;

--- a/styleguide/examples/FormControl.md
+++ b/styleguide/examples/FormControl.md
@@ -10,9 +10,6 @@
 <FormControl fcSize="sm">
     Small
 </FormControl>
-<FormControl fcSize="xs">
-    Extra small
-</FormControl>
 ```
 
 ### Plain text

--- a/styleguide/examples/Input.md
+++ b/styleguide/examples/Input.md
@@ -4,7 +4,6 @@
 <Input type="text" fcSize="lg" placeholder="Large input" />
 <Input type="text" fcSize="md" placeholder="Medium input" />
 <Input type="text" fcSize="sm" placeholder="Small input" />
-<Input type="text" fcSize="xs" placeholder="Extra small input" />
 ```
 
 ### Attributes

--- a/styleguide/examples/Select.md
+++ b/styleguide/examples/Select.md
@@ -10,9 +10,6 @@
 <Select fcSize="sm">
     <option>Small select</option>
 </Select>
-<Select fcSize="xs">
-    <option>Extra small select</option>
-</Select>
 ```
 
 ### Attributes


### PR DESCRIPTION
Closes #2

Form control in extra small size is not practical and not a good design for UX. It will be removed in next major release.